### PR TITLE
Update to generation of the nexus entry

### DIFF
--- a/suitcase/nomad_camels_hdf5/__init__.py
+++ b/suitcase/nomad_camels_hdf5/__init__.py
@@ -1023,7 +1023,7 @@ class Serializer(event_model.DocumentRouter):
             if self.do_nexus_output:
                 self.make_nexus_structure()
         
-            self.nxcollection_default_class()
+            nxcollection_default_class(self._h5_output_file)
 
         self.close()
 
@@ -1187,4 +1187,4 @@ def nxcollection_default_class(group):
         if isinstance(group[key], h5py.Group):
             if not "NX_class" in group[key].attrs:
                 group[key].attrs["NX_class"] = "NXcollection"
-            make_nx_classes_collection(group[key])
+            nxcollection_default_class(group[key])

--- a/suitcase/nomad_camels_hdf5/__init__.py
+++ b/suitcase/nomad_camels_hdf5/__init__.py
@@ -1150,8 +1150,6 @@ class Serializer(event_model.DocumentRouter):
                         outputs_list.append(output_name)
                 else:
                     instrument[child] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/{child}")
-            environment.create_group("pid")
-            environment["pid"].attrs["NX_class"] = "NXpid"
             environment["independent_controllers"] = " ".join(outputs_list)
             environment["measurement_sensors"] = " ".join(sensors_list)
         self.data_to_flat_structure(nexus_name=nexus_name, group_name="data", group_path="data")

--- a/suitcase/nomad_camels_hdf5/__init__.py
+++ b/suitcase/nomad_camels_hdf5/__init__.py
@@ -1024,9 +1024,9 @@ class Serializer(event_model.DocumentRouter):
                 self.make_nexus_structure()
         
             nxcollection_default_class(self._h5_output_file)
-        self._h5_output_file.attrs["h5py_version"] = h5py.__version__
-        self._h5_output_file.attrs["HDF5_Version"] = h5py.version.hdf5_version
-        self._h5_output_file.attrs["file_time"] = timestamp_to_ISO8601(self._start_time)
+            self._h5_output_file.attrs["h5py_version"] = h5py.__version__
+            self._h5_output_file.attrs["HDF5_Version"] = h5py.version.hdf5_version
+            self._h5_output_file.attrs["file_time"] = timestamp_to_ISO8601(self._start_time)
 
         self.close()
 

--- a/suitcase/nomad_camels_hdf5/__init__.py
+++ b/suitcase/nomad_camels_hdf5/__init__.py
@@ -1024,6 +1024,9 @@ class Serializer(event_model.DocumentRouter):
                 self.make_nexus_structure()
         
             nxcollection_default_class(self._h5_output_file)
+        self._h5_output_file.attrs["h5py_version"] = h5py.__version__
+        self._h5_output_file.attrs["HDF5_Version"] = h5py.version.hdf5_version
+        self._h5_output_file.attrs["file_time"] = timestamp_to_ISO8601(self._start_time)
 
         self.close()
 
@@ -1165,9 +1168,6 @@ class Serializer(event_model.DocumentRouter):
         )
         self._h5_output_file.attrs["default"] = nexus_name
         nx_group.attrs["default"] = "data"
-        self._h5_output_file.attrs["h5py_version"] = h5py.__version__
-        self._h5_output_file.attrs["HDF5_Version"] = h5py.version.hdf5_version
-        self._h5_output_file.attrs["file_time"] = timestamp_to_ISO8601(self._start_time)
 
     def data_to_flat_structure(self, nexus_name, group_name, group_path):
         # copy group and its attributes, but not datasets and not subgroups

--- a/suitcase/nomad_camels_hdf5/__init__.py
+++ b/suitcase/nomad_camels_hdf5/__init__.py
@@ -276,8 +276,7 @@ class FileManager:
     def reserve_name(self, entry_name, relative_file_path):
         if Path(relative_file_path).is_absolute():
             raise SuitcaseUtilsValueError(
-                f"{relative_file_path!r} must be structured like a relative "
-                f"file path."
+                f"{relative_file_path!r} must be structured like a relative file path."
             )
         abs_file_path = (
             (self.directory / Path(relative_file_path)).expanduser().resolve()
@@ -300,9 +299,9 @@ class FileManager:
             or os.path.isfile(abs_file_path)
             and self._new_file_each
         ):
-            if abs_file_path.endswith(f"_{i-1}{self.file_extension}"):
+            if abs_file_path.endswith(f"_{i - 1}{self.file_extension}"):
                 abs_file_path = abs_file_path.replace(
-                    f"_{i-1}{self.file_extension}", f"_{i}{self.file_extension}"
+                    f"_{i - 1}{self.file_extension}", f"_{i}{self.file_extension}"
                 )
             else:
                 abs_file_path = (
@@ -557,8 +556,8 @@ class Serializer(event_model.DocumentRouter):
         self._h5_output_file.attrs["NX_class"] = "NXroot"
         entry_name = "CAMELS_" + entry_name
         while entry_name in self._h5_output_file:
-            if entry_name.endswith(f"_{i-1}"):
-                entry_name = entry_name.replace(f"_{i-1}", f"_{i}")
+            if entry_name.endswith(f"_{i - 1}"):
+                entry_name = entry_name.replace(f"_{i - 1}", f"_{i}")
             else:
                 entry_name += f"_{i}"
             i += 1
@@ -727,7 +726,7 @@ class Serializer(event_model.DocumentRouter):
             used_keys = []
             for key, val in dat.items():
                 if key.startswith("python_file_"):
-                    if not "driver_files" in dev_group:
+                    if "driver_files" not in dev_group:
                         dev_group.create_group("driver_files")
                         dev_group["driver_files"].attrs["NX_class"] = "NXcollection"
                     dev_group["driver_files"][key] = val
@@ -1022,11 +1021,13 @@ class Serializer(event_model.DocumentRouter):
 
             if self.do_nexus_output:
                 self.make_nexus_structure()
-        
+
             nxcollection_default_class(self._h5_output_file)
             self._h5_output_file.attrs["h5py_version"] = h5py.__version__
             self._h5_output_file.attrs["HDF5_Version"] = h5py.version.hdf5_version
-            self._h5_output_file.attrs["file_time"] = timestamp_to_ISO8601(self._start_time)
+            self._h5_output_file.attrs["file_time"] = timestamp_to_ISO8601(
+                self._start_time
+            )
 
         self.close()
 
@@ -1052,7 +1053,10 @@ class Serializer(event_model.DocumentRouter):
         )
         process = nx_group.create_group("process")
         process.attrs["NX_class"] = "NXprocess"
-        self._h5_output_file.copy(f"/{self._entry_name}/program/program_name", f"/{nexus_name}/process/program")
+        self._h5_output_file.copy(
+            f"/{self._entry_name}/program/program_name",
+            f"/{nexus_name}/process/program",
+        )
         try:
             version = self._entry["program"]["version"]
         except (KeyError, TypeError):
@@ -1066,16 +1070,23 @@ class Serializer(event_model.DocumentRouter):
         process.create_group("python_environment")
         process["python_environment"].attrs["NX_class"] = "NXparamerters"
         for package in self._entry["program"]["python_environment"]:
-            process["python_environment"][package] = h5py.SoftLink(f"/{self._entry_name}/program/python_environment/{package}")
+            process["python_environment"][package] = h5py.SoftLink(
+                f"/{self._entry_name}/program/python_environment/{package}"
+            )
         process.create_group("python")
         process["python"].attrs["NX_class"] = "NXparamerters"
-        process["python"]["python_version"] = self._entry["program"]["python_environment"].attrs["python_version"]
+        process["python"]["python_version"] = self._entry["program"][
+            "python_environment"
+        ].attrs["python_version"]
         # additional fields may be added to user and sample of nexus entry, so adding links by element, not to the whole group
         user = nx_group.create_group("user")
         user.attrs["NX_class"] = "NXuser"
         for field in self._entry["user"]:
             if field == "identifier":
-                self._h5_output_file.copy(f"/{self._entry_name}/user/identifier/identifier", f"/{nexus_name}/user/identifier_user")
+                self._h5_output_file.copy(
+                    f"/{self._entry_name}/user/identifier/identifier",
+                    f"/{nexus_name}/user/identifier_user",
+                )
                 try:
                     service = self._entry["user"]["identifier"]["service"]
                 except (KeyError, TypeError):
@@ -1090,7 +1101,10 @@ class Serializer(event_model.DocumentRouter):
         for field in self._entry["sample"]:
             if field == "sample_id":
                 if self._entry["sample"]["sample_id"][()]:
-                    self._h5_output_file.copy(f"/{self._entry_name}/sample/sample_id", f"/{nexus_name}/sample/identifier_sample")
+                    self._h5_output_file.copy(
+                        f"/{self._entry_name}/sample/sample_id",
+                        f"/{nexus_name}/sample/identifier_sample",
+                    )
                     sample["identifier_sample"].attrs["type"] = "laboratory specific"
                     sample["identifier_sample"].attrs["custom"] = True
             else:
@@ -1105,11 +1119,19 @@ class Serializer(event_model.DocumentRouter):
             for child in self._entry["instruments"][dev]:
                 if child == "ELN-instrument-id":
                     if self._entry["instruments"][dev]["ELN-instrument-id"][()]:
-                        self._h5_output_file.copy(f"/{self._entry_name}/instruments/{dev}/ELN-instrument-id", f"/{nexus_name}/{dev}/identifier_ELN_instrument")
-                        instrument["identifier_ELN_instrument"].attrs["type"] = "laboratory specific"
+                        self._h5_output_file.copy(
+                            f"/{self._entry_name}/instruments/{dev}/ELN-instrument-id",
+                            f"/{nexus_name}/{dev}/identifier_ELN_instrument",
+                        )
+                        instrument["identifier_ELN_instrument"].attrs["type"] = (
+                            "laboratory specific"
+                        )
                         instrument["identifier_ELN_instrument"].attrs["custom"] = True
                 elif child == "name":
-                    self._h5_output_file.copy(f"/{self._entry_name}/instruments/{dev}/name", f"/{nexus_name}/{dev}/name")
+                    self._h5_output_file.copy(
+                        f"/{self._entry_name}/instruments/{dev}/name",
+                        f"/{nexus_name}/{dev}/name",
+                    )
                     try:
                         short_name = self._entry["instruments"][dev]["short_name"]
                     except (KeyError, TypeError):
@@ -1121,38 +1143,58 @@ class Serializer(event_model.DocumentRouter):
                     settings = instrument.create_group("settings")
                     settings.attrs["NX_class"] = "NXparameters"
                     for field in self._entry["instruments"][dev]["settings"]:
-                        settings[field] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/settings/{field}")
+                        settings[field] = h5py.SoftLink(
+                            f"/{self._entry_name}/instruments/{dev}/settings/{field}"
+                        )
                 elif child == "config_channel_metadata":
                     configs = instrument.create_group("config_channel_metadata")
                     configs.attrs["NX_class"] = "NXparameters"
-                    for field in self._entry["instruments"][dev]["config_channel_metadata"]:
-                        configs[field] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/config_channel_metadata/{field}")
+                    for field in self._entry["instruments"][dev][
+                        "config_channel_metadata"
+                    ]:
+                        configs[field] = h5py.SoftLink(
+                            f"/{self._entry_name}/instruments/{dev}/config_channel_metadata/{field}"
+                        )
                 elif child == "sensors":
                     for sensor_name in self._entry["instruments"][dev]["sensors"]:
-                        instrument[sensor_name] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/sensors/{sensor_name}")
+                        instrument[sensor_name] = h5py.SoftLink(
+                            f"/{self._entry_name}/instruments/{dev}/sensors/{sensor_name}"
+                        )
                         environment.create_group(sensor_name)
                         environment[sensor_name].attrs["NX_class"] = "NXsensor"
-                        for sensor_child in self._entry["instruments"][dev]["sensors"][sensor_name]:
+                        for sensor_child in self._entry["instruments"][dev]["sensors"][
+                            sensor_name
+                        ]:
                             environment[sensor_name][sensor_child] = h5py.SoftLink(
                                 f"/{self._entry_name}/instruments/{dev}/sensors/{sensor_name}/{sensor_child}"
                             )
-                        environment[sensor_name]["calibration_time"] = "1970-01-01T01:00:00+01:00"  # has to be NX_DATE_TIME, not really known
+                        environment[sensor_name]["calibration_time"] = (
+                            "1970-01-01T01:00:00+01:00"  # has to be NX_DATE_TIME, not really known
+                        )
                         environment[sensor_name]["run_control"] = ""
-                        environment[sensor_name]["run_control"].attrs[
-                            "description"
-                        ] = ""
+                        environment[sensor_name]["run_control"].attrs["description"] = (
+                            ""
+                        )
                         environment[sensor_name]["value"] = 0.0
                         sensors_list.append(sensor_name)
                 elif child == "outputs":
                     for output_name in self._entry["instruments"][dev]["outputs"]:
-                        instrument[output_name] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/outputs/{output_name}")
-                        environment[output_name] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/outputs/{output_name}")
+                        instrument[output_name] = h5py.SoftLink(
+                            f"/{self._entry_name}/instruments/{dev}/outputs/{output_name}"
+                        )
+                        environment[output_name] = h5py.SoftLink(
+                            f"/{self._entry_name}/instruments/{dev}/outputs/{output_name}"
+                        )
                         outputs_list.append(output_name)
                 else:
-                    instrument[child] = h5py.SoftLink(f"/{self._entry_name}/instruments/{dev}/{child}")
+                    instrument[child] = h5py.SoftLink(
+                        f"/{self._entry_name}/instruments/{dev}/{child}"
+                    )
             environment["independent_controllers"] = " ".join(outputs_list)
             environment["measurement_sensors"] = " ".join(sensors_list)
-        self.data_to_flat_structure(nexus_name=nexus_name, group_name="data", group_path="data")
+        self.data_to_flat_structure(
+            nexus_name=nexus_name, group_name="data", group_path="data"
+        )
         nx_group["additional_information"] = h5py.SoftLink(
             f"/{self._entry_name}/measurement_details"
         )
@@ -1175,14 +1217,20 @@ class Serializer(event_model.DocumentRouter):
         # softlink all datasets, but not subgroups; recursively call this function for subgroups
         for child in self._entry[group_path]:
             if isinstance(self._entry[group_path][child], h5py.Group):
-                self.data_to_flat_structure(nexus_name=nexus_name, group_name=child, group_path=f"{group_path}/{child}")
+                self.data_to_flat_structure(
+                    nexus_name=nexus_name,
+                    group_name=child,
+                    group_path=f"{group_path}/{child}",
+                )
             else:
-                self._h5_output_file[nexus_name][group_name][child] = h5py.SoftLink(f"/{self._entry_name}/{group_path}/{child}")
+                self._h5_output_file[nexus_name][group_name][child] = h5py.SoftLink(
+                    f"/{self._entry_name}/{group_path}/{child}"
+                )
 
 
 def nxcollection_default_class(group):
     for key in group:
         if isinstance(group[key], h5py.Group):
-            if not "NX_class" in group[key].attrs:
+            if "NX_class" not in group[key].attrs:
                 group[key].attrs["NX_class"] = "NXcollection"
             nxcollection_default_class(group[key])


### PR DESCRIPTION
1. In the previous version function make_nexus_structure() not only created NeXus_... entry, but also modified the original CAMELS entry. This was caused by
        a) groups and datasets connected by SoftLink and then modified in NeXus entry - as it is physically the same object, it was also modified in CAMELS entry. Example: "environment" group created within NXinstrument for both entries
        b) operation b = a for two groups or datasets (but not attributes) seems to be also an operation on a pointer to group/dataset, not their content. Not completely sure here, just tried to avoid the structure in the end
2. Multiple improvements that aim to make NeXus entry actually nexus-compatible. This includes:
   a) replacement of NXidentifier (no more part of nexus) with identifierNAME field in NXobject
   b) measurement_description -> experiment_description
   c) python environment and version moved to "process" and now have class NXparameters
   d) sensors and outputs in instruments now sit directly in the instrument
   e) short_name of instrument is now an attribute
   f) added list of independent controllers to the list of sensors into instruments/environment
   g) instrument/settings and instrument/config... are now NXparameters
   h) set calibration_time to default value (1970.01.01) as it can not be an empty string
   i) check if sample/user id exist before creating corresponding fields - these fields are not mandatory, but empty string is not accepted
   j) flatten NXdata structure - no more nested folders there, instead multiple NXdata if needed
   k) created NXnote for some information on protocols
   l) removed program information from additional_information - this is already mentioned elsewhere.
   m) measurement details are not in additional_information/measurement_details, but directly in additional_information now
   n) added some metainfo as attributes to NXroot
3. Finally, some general modification, affecting both CAMELS and NeXus entries:
   a) time and ElapsedTime now have units of seconds
   b) all groups without NX_class now have NXcollection assigned, as it is a generic enough class
   c) made try/except blocks more specific by specifying (KeyError, TypeError) - other error should still be treated as errors