### PR TITLE
update recursive call of data_to_flat_structure()

### DIFF
--- a/suitcase/nomad_camels_hdf5/__init__.py
+++ b/suitcase/nomad_camels_hdf5/__init__.py
@@ -1219,7 +1219,7 @@ class Serializer(event_model.DocumentRouter):
             if isinstance(self._entry[group_path][child], h5py.Group):
                 self.data_to_flat_structure(
                     nexus_name=nexus_name,
-                    group_name=child,
+                    group_name=group_name+"_"+child,
                     group_path=f"{group_path}/{child}",
                 )
             else:


### PR DESCRIPTION
In case of complex enough nested structure of data in CAMELS entry, data_to_flat_structure() might create groups with same names in NeXus entry, causing errors. Now the new names are not just the same as names of corresponding group in CAMELS entry, but have structure of `data_<child name>_<grandchild name>_...`, so all the names are unique.